### PR TITLE
ADD script for deploying Lambda in all regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Deployment
 Once you're convinced the CloudWatch Event rule(s) and Lambda(s) are working well together, you can run serverless commands
 un all regions (if you dare) by running the deployment script.
 
-- `./sls-everywhere.sh <deploy|remove|etc...>`
+- `./sls-everywhere.sh <deploy|remove|etc...> <slack-webhook-path>`
 
 To-Dos
 ------

--- a/sls-everywhere.sh
+++ b/sls-everywhere.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+COMMAND=${1}
+PATH=${2}
+
+ALL_REGIONS=`aws ec2 describe-regions --region us-east-1 --output text | cut -f 3 | head -1`
+
+for region in ${ALL_REGIONS}
+do
+    echo "Running '${COMMAND} in '${region} ..."
+    sls ${COMMAND} --region ${region} --slack-webhook-path ${PATH}
+done;
+


### PR DESCRIPTION
I've re-added the `sls-everywhere.sh` script without the reference to the slack `/services` path. I'm a bit confused by the `| HEAD -1` part of the script. Could you explain a bit further before merging?